### PR TITLE
Refactor asset creation

### DIFF
--- a/example/src/containers/MetaMaskConnector/MetaMaskConnector.tsx
+++ b/example/src/containers/MetaMaskConnector/MetaMaskConnector.tsx
@@ -3,6 +3,7 @@ import React, {useCallback, useContext} from "react";
 import Alert from "@material-ui/lab/Alert";
 import {MetamaskActions, MetaMaskContext} from "../../context/metamask";
 import {installPolkadotSnap} from "../../services/metamask";
+import {addDotAsset} from "../../services/asset";
 
 export const MetaMaskConnector = () => {
 
@@ -13,6 +14,10 @@ export const MetaMaskConnector = () => {
        if(!isInitiated) {
            alert("Failed to install snap");
        } else {
+           const dotAssetAdded = await addDotAsset();
+           if (!dotAssetAdded) {
+               alert("Failed to add dot asset to metamask");
+           }
            dispatch({type: MetamaskActions.SET_INSTALLED_STATUS, payload: true});
        }
     }, [dispatch]);

--- a/example/src/services/asset.ts
+++ b/example/src/services/asset.ts
@@ -1,0 +1,16 @@
+import {pluginOrigin} from "./metamask";
+
+export async function addDotAsset(): Promise<boolean> {
+    try {
+        await window.ethereum.send({
+            method: pluginOrigin,
+            params: [{
+                method: 'addDotAsset'
+            }]
+        });
+        return true;
+    } catch (e) {
+        console.log(e);
+        return false;
+    }
+}

--- a/example/src/services/metamask.ts
+++ b/example/src/services/metamask.ts
@@ -15,9 +15,10 @@ export function hasMetaMask(): boolean {
 
 }
 
+export const origin = new URL('package.json', 'http://localhost:8081').toString();
+export const pluginOrigin = `wallet_plugin_${origin}`;
+
 export async function installPolkadotSnap(): Promise<boolean> {
-    const origin = new URL('package.json', 'http://localhost:8081').toString();
-    const pluginOrigin = `wallet_plugin_${origin}`;
     try {
         await window.ethereum.send({
             method: 'wallet_enable',

--- a/index.html
+++ b/index.html
@@ -29,7 +29,9 @@
       <!-- Snap connect button -->
       <div style="margin-bottom: 10px">
         <button class="connect-snap">Connect polkadot snap</button>
+        <button class="create-asset">Create dot asset</button>
       </div>
+
       <!-- Public Key -->
       <div style="display: inline">Public key:</div>
       <div class="publicKey" style="display: inline; font-weight: bold"></div>
@@ -116,6 +118,9 @@
     snapConnectButton.addEventListener('click', connectSnap);
     snapConnectButton.disabled = false; // until keypair is fetched
     snapConnectedLabel.innerHTML = FALSE;
+    // create asset
+    const createAssetButton = document.querySelector('button.create-asset');
+    createAssetButton.addEventListener('click', createAsset);
     // export seed
     const exportButton = document.querySelector('button.export-seed');
     const seedLabel = document.querySelector('div.seed');
@@ -143,6 +148,19 @@
     const blockFindButton = document.querySelector('button.block-find');
     const blockData = document.querySelector('pre.block-data');
     blockFindButton.addEventListener('click', findBlock);
+
+    async function createAsset() {
+      try {
+        await ethereum.send({
+          method: snapId,
+          params: [{
+            method: 'createDotAsset'
+          }]
+        });
+      } catch (e) {
+        console.log("Keys not generated", e);
+      }
+    }
 
     async function findBlock() {
       let block = null;

--- a/src/asset/executeAssetOperation.ts
+++ b/src/asset/executeAssetOperation.ts
@@ -1,6 +1,7 @@
 import {Asset, Wallet} from "../interfaces";
 
-export function executeAssetOperation(asset: Asset, wallet: Wallet, method: "update" | "add"): Promise<Asset> {
+// eslint-disable-next-line max-len
+export function executeAssetOperation(asset: Asset, wallet: Wallet, method: "update" | "add" | "remove"): Promise<Asset> {
   return wallet.send({
     method: 'wallet_manageAssets',
     params: [ method, asset ],

--- a/src/asset/unit.ts
+++ b/src/asset/unit.ts
@@ -19,5 +19,7 @@ export async function createPolkadotAsset(wallet: Wallet, api: ApiPromise, metho
   const balance = await getBalance(wallet, api);
   const address = await getAddress(wallet);
   const asset = getPolkadotAssetDescription(balance, address);
+  // remove asset if already created
+  await executeAssetOperation(asset, wallet, "remove");
   return await executeAssetOperation(asset, wallet, method);
 }

--- a/src/snap.ts
+++ b/src/snap.ts
@@ -11,7 +11,7 @@ import {createPolkadotAsset} from "./asset/unit";
 
 declare let wallet: Wallet;
 
-const apiDependentMethods = ["getBlock", "getBalance", "getChainHead", "getPublicKey"];
+const apiDependentMethods = ["getBlock", "getBalance", "getChainHead", "addDotAsset"];
 
 wallet.registerRpcMessageHandler(async (originString, requestObject) => {
   // init api if needed
@@ -21,7 +21,6 @@ wallet.registerRpcMessageHandler(async (originString, requestObject) => {
   }
   switch (requestObject.method) {
     case 'getPublicKey':
-      await createPolkadotAsset(wallet, api, "add");
       return await getPublicKey(wallet);
     case 'getAddress':
       return await getAddress(wallet);
@@ -32,8 +31,9 @@ wallet.registerRpcMessageHandler(async (originString, requestObject) => {
     case 'getBlock':
       return await getBlock(requestObject.params, api);
     case 'getBalance':
-      await createPolkadotAsset(wallet, api, "update"); // just for showcase
       return await getBalance(wallet, api);
+    case 'addDotAsset':
+      return await createPolkadotAsset(wallet, api, "add");
     case 'getChainHead':
       // temporary method
       const head = await api.rpc.chain.getFinalizedHead();


### PR DESCRIPTION
Currently, it is just calling the RPC method for creating a new asset and not checking existing assets. 

I am investigating how to fetch existing assets. I see there is this [proposal ](https://ethereum-magicians.org/t/eip-2256-add-wallet-getownedassets-json-rpc-method/3600), but not sure how to fetch assets.