### PR TITLE
Reset api on configure call

### DIFF
--- a/packages/snap/src/polkadot/api.ts
+++ b/packages/snap/src/polkadot/api.ts
@@ -21,6 +21,13 @@ async function initApi(wsRpcUrl: string): Promise<ApiPromise> {
   return api;
 }
 
+export const resetApi = (): void => {
+  api.disconnect();
+  provider.disconnect();
+  api = null;
+  provider = null;
+};
+
 export const getApi = async (wallet: Wallet): Promise<ApiPromise> => {
   if (!api) {
     // first api initialization

--- a/packages/snap/src/snap.ts
+++ b/packages/snap/src/snap.ts
@@ -7,7 +7,7 @@ import ApiPromise from "@polkadot/api/promise";
 import {getTransactions} from "./rpc/substrate/getTransactions";
 import {getBlock} from "./rpc/substrate/getBlock";
 import {removeAsset, updateAsset} from "./asset";
-import {getApi} from "./polkadot/api";
+import {getApi, resetApi} from "./polkadot/api";
 import {configure} from "./rpc/configure";
 import {polkadotEventEmitter} from "./polkadot/events";
 import {registerOnBalanceChange} from "./polkadot/events/balance";
@@ -68,6 +68,7 @@ wallet.registerRpcMessageHandler(async (originString, requestObject) => {
       return balance;
     }
     case 'configure': {
+      resetApi();
       return configure(wallet, requestObject.params.configuration.networkName, requestObject.params.configuration);
     }
     case 'addPolkadotAsset':


### PR DESCRIPTION
Fix API not being reinitialized after setting new configuration trough `configure` RPC call. The reason why it didn't work as expected is that `api` was initialized and **if condition** was true only on first initialization as seen below. Now `api` is disconnected and set to `null` on `configure` call so it will be reinitialized on the next call of `getApi` function.

```ts
export const getApi = async (wallet: Wallet): Promise<ApiPromise> => {
  const config = getConfiguration(wallet);
  // api not initialized or configuration changed
  if (!api) {
    // first api initialization
    api = await initApi(config.wsRpcUrl);
    isConnecting = false;
  } else {
    ...
  }
```