### PR TITLE
Unit sending

### DIFF
--- a/packages/example/src/components/Account/Account.tsx
+++ b/packages/example/src/components/Account/Account.tsx
@@ -47,4 +47,4 @@ export const Account = (props: AccountProps) => {
             </CardContent>
         </Card>
     );
-}
+};

--- a/packages/example/src/components/Transfer/Transfer.tsx
+++ b/packages/example/src/components/Transfer/Transfer.tsx
@@ -14,6 +14,7 @@ import {getInjectedMetamaskExtension} from "../../services/metamask";
 import {Alert} from "@material-ui/lab";
 import {getPolkascanBlockUrl, getPolkascanTxUrl} from "../../services/polkascan";
 import {TxEventArgument} from "@nodefactory/metamask-polkadot-types";
+import {findSi, formatBalance} from "@polkadot/util";
 
 interface ITransferProps {
     network: string
@@ -32,9 +33,20 @@ export const Transfer: React.FC<ITransferProps> = ({network}) => {
 
     const handleCurrency = (network: string): string => {
         switch(network) {
-            case "kusama": return "KSM";
+            case "kusama":
+                return "KSM";
             case "westend":
                 return "mWND";
+            default: return ""
+        }
+    };
+
+    const currencyMul = (network: string): string => {
+        switch(network) {
+            case "kusama":
+                return "1";
+            case "westend":
+                return "1000000000";
             default: return ""
         }
     };
@@ -79,8 +91,8 @@ export const Transfer: React.FC<ITransferProps> = ({network}) => {
         if(provider && provider.signer.signPayload) {
             if (amount && recipient) {
                 const api = await provider.getMetamaskSnapApi();
-                const amountWND = BigInt(amount) * BigInt("1000000000");
-                const txPayload = await api.generateTransactionPayload(amountWND.toString(), recipient);
+                const convertedAmount = BigInt(amount) * BigInt(currencyMul(network));
+                const txPayload = await api.generateTransactionPayload(convertedAmount.toString(), recipient);
                 const signedTx = await provider.signer.signPayload(txPayload.payload);
                 let txHash = await api.send(signedTx.signature, txPayload);
                 // subscribe to transaction events

--- a/packages/example/src/components/Transfer/Transfer.tsx
+++ b/packages/example/src/components/Transfer/Transfer.tsx
@@ -6,13 +6,14 @@ import {
     CardContent,
     CardHeader,
     Grid,
-    TextField,
+    Hidden,
     InputAdornment,
-    Snackbar, Hidden
+    Snackbar,
+    TextField
 } from '@material-ui/core/';
 import {getInjectedMetamaskExtension} from "../../services/metamask";
 import {Alert} from "@material-ui/lab";
-import {getPolkascanBlockUrl, getPolkascanTxUrl} from "../../services/polkascan";
+import {getPolkascanTxUrl} from "../../services/polkascan";
 import {TxEventArgument} from "@nodefactory/metamask-polkadot-types";
 import {getCurrency} from "../../services/format";
 
@@ -40,17 +41,17 @@ export const Transfer: React.FC<ITransferProps> = ({network}) => {
     }, [setAmount]);
 
     const handleTransactionIncluded = useCallback((tx: TxEventArgument) => {
-        if (tx.txHash && tx.blockHash) {
+        if (tx.txHash) {
             showAlert(
                 "success",
                 `Transaction ${tx.txHash} included in block`,
-                getPolkascanBlockUrl(tx.blockHash, network)
+                getPolkascanTxUrl(tx.txHash, network)
             );
         }
     }, [network]);
 
     const handleTransactionFinalized = useCallback((tx: TxEventArgument) => {
-        if (tx.txHash && tx.blockHash) {
+        if (tx.txHash) {
             showAlert(
                 "success",
                 `Transaction ${tx.txHash} finalized`,
@@ -98,7 +99,7 @@ export const Transfer: React.FC<ITransferProps> = ({network}) => {
                         onChange={handleRecipientChange} size="medium" fullWidth id="recipient" label="Recipient" variant="outlined" value={recipient}>
                         </TextField>
                         <Box m="0.5rem"/>
-                        <TextField 
+                        <TextField
                         InputProps={{startAdornment: <InputAdornment position="start">{`m${getCurrency(network)}`}</InputAdornment>}}
                         onChange={handleAmountChange} size="medium" fullWidth id="recipient" label="Amount" variant="outlined" value={amount}>
                         </TextField>

--- a/packages/example/src/components/Transfer/Transfer.tsx
+++ b/packages/example/src/components/Transfer/Transfer.tsx
@@ -14,7 +14,6 @@ import {getInjectedMetamaskExtension} from "../../services/metamask";
 import {Alert} from "@material-ui/lab";
 import {getPolkascanBlockUrl, getPolkascanTxUrl} from "../../services/polkascan";
 import {TxEventArgument} from "@nodefactory/metamask-polkadot-types";
-import {findSi, formatBalance} from "@polkadot/util";
 
 interface ITransferProps {
     network: string
@@ -105,7 +104,7 @@ export const Transfer: React.FC<ITransferProps> = ({network}) => {
                 showAlert("error", "Please fill recipient and amount fields.");
             }
         }
-    }, [amount, handleTransactionFinalized, handleTransactionIncluded, recipient, setAmount, setRecipient]);
+    }, [amount, handleTransactionFinalized, handleTransactionIncluded, recipient, setAmount, setRecipient, network]);
 
     return (
         <Card>

--- a/packages/example/src/components/Transfer/Transfer.tsx
+++ b/packages/example/src/components/Transfer/Transfer.tsx
@@ -86,7 +86,7 @@ export const Transfer: React.FC<ITransferProps> = ({network}) => {
                 showAlert("error", "Please fill recipient and amount fields.");
             }
         }
-    }, [amount, handleTransactionFinalized, handleTransactionIncluded, recipient, setAmount, setRecipient, network]);
+    }, [amount, handleTransactionFinalized, handleTransactionIncluded, recipient, setAmount, setRecipient]);
 
     return (
         <Card>

--- a/packages/example/src/containers/Dashboard/Dashboard.tsx
+++ b/packages/example/src/containers/Dashboard/Dashboard.tsx
@@ -66,15 +66,11 @@ export const Dashboard = () => {
         const api = eventApi;
         if(api) {
             (async function () {
-                console.log("subscribing");
-                // @ts-ignore
                 api.subscribeToBalance(handleBalanceChange);
             })();
         }
         return function () {
-            console.log("cleaning", api);
             if (api) {
-                console.log("unsubscribing");
                 api.unsubscribeAllFromBalance();
             }
         }
@@ -83,7 +79,6 @@ export const Dashboard = () => {
     useEffect(() => {
         (async () => {
             if (state.polkadotSnap.isInstalled) {
-                console.log("Updating values");
                 const extension = await getInjectedMetamaskExtension();
                 if (!extension) return;
                 const metamaskSnapApi = await extension.getMetamaskSnapApi();

--- a/packages/example/src/services/polkascan.ts
+++ b/packages/example/src/services/polkascan.ts
@@ -2,14 +2,6 @@ export function getPolkascanTxUrl(txHash: string, network: string): string {
     return `${getPolkascanBaseUrl(network)}/transaction/${txHash}`;
 }
 
-export function getPolkascanAccUrl(address: string, network: string): string {
-    return `${getPolkascanBaseUrl(network)}/account/${address}`;
-}
-
-export function getPolkascanBlockUrl(block: string, network: string) {
-    return`${getPolkascanBaseUrl(network)}/block/${block}`;
-}
-
 function getPolkascanBaseUrl(network: string): string {
     switch (network) {
         case "kusama":

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -55,7 +55,7 @@
     }
   },
   "devDependencies": {
-    "@nodefactory/snaps-cli": "^1.0.0",
+    "@nodefactory/snaps-cli": "1.0.0",
     "@types/chai": "^4.2.10",
     "@types/mocha": "^7.0.2",
     "@types/sinon": "^7.5.2",

--- a/packages/snap/src/polkadot/api.ts
+++ b/packages/snap/src/polkadot/api.ts
@@ -2,6 +2,7 @@ import ApiPromise from "@polkadot/api/promise";
 import {WsProvider} from "@polkadot/api";
 import {Wallet} from "../interfaces";
 import {getConfiguration} from "../configuration";
+import U8aFixed from "@polkadot/types/codec/U8aFixed";
 
 let api: ApiPromise;
 let provider: WsProvider;
@@ -17,6 +18,7 @@ async function initApi(wsRpcUrl: string): Promise<ApiPromise> {
     provider,
     types: {
       //tmp fix until we figure out how to update polkadot api lib
+      ModuleId: U8aFixed,
       RuntimeDbWeight: {
         read: 'Weight',
         write: 'Weight'

--- a/packages/snap/src/polkadot/events/balance/index.ts
+++ b/packages/snap/src/polkadot/events/balance/index.ts
@@ -10,27 +10,27 @@ export async function registerOnBalanceChange(wallet: Wallet, origin: string): P
   const api = await getApi(wallet);
   const address = (await getKeyPair(wallet)).address;
   // Here we subscribe to any balance changes and update the on-screen value
-  const unsubscribeCallback = await api.query.system.account(address, ({data: { free: currentFree }}) => {
+  await api.query.system.account(address, ({data: { free: currentFree }}) => {
     updateAsset(wallet, origin, currentFree.toString());
     polkadotEventEmitter.emit("onBalanceChange", origin, currentFree.toString());
   });
-  if (!unsubscribe) {
-    unsubscribe = {
-      [origin]: unsubscribeCallback
-    };
-  } else {
-    // clean up if already subscribed
-    if (unsubscribe[origin]) {
-      unsubscribe[origin]();
-    }
-    // register new unsubscribe callback
-    unsubscribe[origin] = unsubscribeCallback;
-  }
+  // if (!unsubscribe) {
+  //   unsubscribe = {
+  //     [origin]: unsubscribeCallback
+  //   };
+  // } else {
+  //   // clean up if already subscribed
+  //   if (unsubscribe[origin]) {
+  //     unsubscribe[origin]();
+  //   }
+  //   // register new unsubscribe callback
+  //   unsubscribe[origin] = unsubscribeCallback;
+  // }
 }
 
 export function removeOnBalanceChange(origin: string): void {
-  if (unsubscribe && unsubscribe[origin]) {
-    unsubscribe[origin]();
-    delete unsubscribe[origin];
-  }
+  // if (unsubscribe && unsubscribe[origin]) {
+  //   unsubscribe[origin]();
+  //   delete unsubscribe[origin];
+  // }
 }

--- a/packages/snap/src/polkadot/events/balance/index.ts
+++ b/packages/snap/src/polkadot/events/balance/index.ts
@@ -2,6 +2,7 @@ import {Wallet} from "../../../interfaces";
 import {polkadotEventEmitter} from "../index";
 import {getApi} from "../../api";
 import {getKeyPair} from "../../account";
+import {updateAsset} from "../../../asset";
 
 let unsubscribe: Record<string, () => void>;
 
@@ -10,6 +11,7 @@ export async function registerOnBalanceChange(wallet: Wallet, origin: string): P
   const address = (await getKeyPair(wallet)).address;
   // Here we subscribe to any balance changes and update the on-screen value
   const unsubscribeCallback = await api.query.system.account(address, ({data: { free: currentFree }}) => {
+    updateAsset(wallet, origin, currentFree.toString());
     polkadotEventEmitter.emit("onBalanceChange", origin, currentFree.toString());
   });
   if (!unsubscribe) {

--- a/packages/snap/src/polkadot/events/emitter.ts
+++ b/packages/snap/src/polkadot/events/emitter.ts
@@ -1,24 +1,24 @@
-import {EventCallback} from "@nodefactory/metamask-polkadot-types";
+import {Callback} from "@nodefactory/metamask-polkadot-types";
 import {EventEmitter} from "./index";
 
-export class EventEmitterImplementation<T extends string, K extends string> implements EventEmitter<T, K> {
+export class EventEmitterImplementation<T extends string, K extends string, J> implements EventEmitter<T, K, J> {
 
-  private listeners: Record<K, Record<T, EventCallback[]>>;
+  private listeners: Record<K, Record<T, Callback<J>[]>>;
 
-  addListener(event: T, identifier: K, listener: (...args: unknown[]) => void): this {
+  addListener(event: T, identifier: K, listener: Callback<J>): this {
     // create listeners structure if first call
     if (!this.listeners) {
       this.listeners = {
         [identifier]: {
           [event]: []
         }
-      } as Record<K, Record<T, EventCallback[]>>;
+      } as Record<K, Record<T, Callback<J>[]>>;
     }
     // initialize slot for origin if it doesn't exist
     if (!this.listeners[identifier]) {
       this.listeners[identifier] = {
         [event]: []
-      } as Record<T, EventCallback[]>;
+      } as Record<T, Callback<J>[]>;
     }
 
     // initialize slot for event if it doesn't exist
@@ -31,15 +31,15 @@ export class EventEmitterImplementation<T extends string, K extends string> impl
     return this;
   }
 
-  emit(event: T, identifier: K, ...args: unknown[]): boolean {
+  emit(event: T, identifier: K, arg: J): boolean {
     if (this.hasAttachedListeners(event, identifier)) {
-      this.listeners[identifier][event].forEach(callback => callback(args));
+      this.listeners[identifier][event].forEach(callback => callback(arg));
       return this.listeners[identifier][event].length != 0;
     }
     return false;
   }
 
-  removeListener(event: T, identifier: K, listener: (...args: unknown[]) => void): this {
+  removeListener(event: T, identifier: K, listener: Callback<J>): this {
     if (this.hasAttachedListeners(event, identifier)) {
       this.listeners[identifier][event] = this.listeners[identifier][event].filter(l => l != listener);
     }

--- a/packages/snap/src/polkadot/events/index.ts
+++ b/packages/snap/src/polkadot/events/index.ts
@@ -1,7 +1,7 @@
 import {Callback, HexHash, Origin, PolkadotEventArgument, TxEventArgument} from "@nodefactory/metamask-polkadot-types";
 import {EventEmitterImplementation} from "./emitter";
 
-export interface EventEmitter<K = keyof string, T = keyof string, J = keyof unknown>  {
+export interface EventEmitter<K, T, J>  {
   addListener(event: K, identifier: T, listener: Callback<J>): this;
   removeListener(event: K, identifier: T, listener: Callback<J>): this;
   removeAllListeners(event: K, identifier: T): this;

--- a/packages/snap/src/polkadot/events/index.ts
+++ b/packages/snap/src/polkadot/events/index.ts
@@ -1,16 +1,19 @@
-import {EventCallback, HexHash, Origin} from "@nodefactory/metamask-polkadot-types";
+import {Callback, HexHash, Origin, PolkadotEventArgument, TxEventArgument} from "@nodefactory/metamask-polkadot-types";
 import {EventEmitterImplementation} from "./emitter";
 
-export interface EventEmitter<K = keyof string, T = keyof string>  {
-  addListener(event: K, identifier: T, listener: EventCallback): this;
-  removeListener(event: K, identifier: T, listener: EventCallback): this;
+export interface EventEmitter<K = keyof string, T = keyof string, J = keyof any>  {
+  addListener(event: K, identifier: T, listener: Callback<J>): this;
+  removeListener(event: K, identifier: T, listener: Callback<J>): this;
   removeAllListeners(event: K, identifier: T): this;
   getListenersCount(event: K, identifier: T): number;
-  emit(event: K, identifier: T, ...args: unknown[]): boolean;
+  emit(event: K, identifier: T, arg: J): boolean;
 }
 
 export type PolkadotEvent = "onBalanceChange" | "onTransactionStatus";
 export type TxStatus = "included" | "finalized";
 
-export const polkadotEventEmitter: EventEmitter<PolkadotEvent, Origin> = new EventEmitterImplementation();
-export const txEventEmitter: EventEmitter<TxStatus, HexHash> = new EventEmitterImplementation();
+export const polkadotEventEmitter: EventEmitter<PolkadotEvent, Origin, PolkadotEventArgument> =
+    new EventEmitterImplementation<PolkadotEvent, Origin, PolkadotEventArgument>();
+
+export const txEventEmitter: EventEmitter<TxStatus, HexHash, TxEventArgument> =
+    new EventEmitterImplementation<TxStatus, HexHash, TxEventArgument>();

--- a/packages/snap/src/polkadot/events/index.ts
+++ b/packages/snap/src/polkadot/events/index.ts
@@ -1,7 +1,7 @@
 import {Callback, HexHash, Origin, PolkadotEventArgument, TxEventArgument} from "@nodefactory/metamask-polkadot-types";
 import {EventEmitterImplementation} from "./emitter";
 
-export interface EventEmitter<K = keyof string, T = keyof string, J = keyof any>  {
+export interface EventEmitter<K = keyof string, T = keyof string, J = keyof unknown>  {
   addListener(event: K, identifier: T, listener: Callback<J>): this;
   removeListener(event: K, identifier: T, listener: Callback<J>): this;
   removeAllListeners(event: K, identifier: T): this;

--- a/packages/snap/src/rpc/send.ts
+++ b/packages/snap/src/rpc/send.ts
@@ -1,23 +1,21 @@
 import {Wallet} from "../interfaces";
 import ApiPromise from "@polkadot/api/promise";
-import { Hash } from '@polkadot/types/interfaces';
 import {TxPayload} from "@nodefactory/metamask-polkadot-types";
 import {getAddress} from "./getAddress";
 import {txEventEmitter} from "../polkadot/events";
 
-export async function send(wallet: Wallet, api: ApiPromise, signature: string, txPayload: TxPayload): Promise<Hash> {
+export async function send(wallet: Wallet, api: ApiPromise, signature: string, txPayload: TxPayload): Promise<string> {
   const extrinsic = api.createType('Extrinsic', txPayload.tx);
   extrinsic.addSignature((await getAddress(wallet)), signature, txPayload.payload);
   const txHash = extrinsic.hash.toHex();
   api.rpc.author.submitAndWatchExtrinsic(extrinsic, result => {
-    const blockHash = result.hash.toHex();
     if (result.isInBlock) {
-      txEventEmitter.emit("included", txHash, {blockHash, txHash});
+      txEventEmitter.emit("included", txHash, {txHash});
       txEventEmitter.removeAllListeners("included", txHash);
     } else if (result.isFinalized) {
-      txEventEmitter.emit("finalized", txHash, {blockHash, txHash});
+      txEventEmitter.emit("finalized", txHash, {txHash});
       txEventEmitter.removeAllListeners("finalized", txHash);
     }
   });
-  return extrinsic.hash;
+  return extrinsic.hash.toHex();
 }

--- a/packages/snap/src/snap.ts
+++ b/packages/snap/src/snap.ts
@@ -11,7 +11,7 @@ import {getApi, resetApi} from "./polkadot/api";
 import {configure} from "./rpc/configure";
 import {polkadotEventEmitter, txEventEmitter} from "./polkadot/events";
 import {registerOnBalanceChange, removeOnBalanceChange} from "./polkadot/events/balance";
-import {EventCallback, HexHash, PolkadotApi} from "@nodefactory/metamask-polkadot-types";
+import {HexHash, PolkadotApi, PolkadotEventCallback, TxEventCallback} from "@nodefactory/metamask-polkadot-types";
 import {signPayloadJSON, signPayloadRaw} from "./rpc/substrate/sign";
 import {generateTransactionPayload} from "./rpc/generateTransactionPayload";
 import {send} from "./rpc/send";
@@ -24,14 +24,14 @@ const apiDependentMethods = [
 
 wallet.registerApiRequestHandler(async function (origin: URL): Promise<PolkadotApi> {
   return {
-    subscribeToBalance: (callback: EventCallback): void => {
+    subscribeToBalance: (callback: PolkadotEventCallback): void => {
       polkadotEventEmitter.addListener("onBalanceChange", origin.hostname, callback);
       // first call or first call after unregistering
       if (polkadotEventEmitter.getListenersCount("onBalanceChange", origin.hostname) === 1) {
         registerOnBalanceChange(wallet, origin.hostname);
       }
     },
-    subscribeToTxStatus: (hash: HexHash, onIncluded: EventCallback, onFinalized?: EventCallback): void => {
+    subscribeToTxStatus: (hash: HexHash, onIncluded: TxEventCallback, onFinalized?: TxEventCallback): void => {
       txEventEmitter.addListener("included", hash, onIncluded);
       if (onFinalized) {
         txEventEmitter.addListener("finalized", hash, onFinalized);
@@ -41,7 +41,7 @@ wallet.registerApiRequestHandler(async function (origin: URL): Promise<PolkadotA
       polkadotEventEmitter.removeAllListeners("onBalanceChange", origin.hostname);
       removeOnBalanceChange(origin.hostname);
     },
-    unsubscribeFromBalance: (callback: EventCallback): void => {
+    unsubscribeFromBalance: (callback: PolkadotEventCallback): void => {
       polkadotEventEmitter.removeListener("onBalanceChange", origin.hostname, callback);
       if (polkadotEventEmitter.getListenersCount("onBalanceChange", origin.hostname) === 0) {
         removeOnBalanceChange(origin.hostname);

--- a/packages/snap/test/unit/polkadot/events/index.test.ts
+++ b/packages/snap/test/unit/polkadot/events/index.test.ts
@@ -24,7 +24,7 @@ describe('Test polkadotEventEmitter', function() {
         "onBalanceChange", "origin1", callbackStub
       );
       polkadotEventEmitter.emit("onBalanceChange", "origin1", "arg");
-      expect(callbackStub).to.have.been.calledOnceWith(["arg"]);
+      expect(callbackStub).to.have.been.calledOnceWith("arg");
       polkadotEventEmitter.removeAllListeners("onBalanceChange", "origin1");
       polkadotEventEmitter.emit("onBalanceChange", "origin1", "arg");
       expect(callbackStub).to.have.been.calledOnce;
@@ -35,7 +35,7 @@ describe('Test polkadotEventEmitter', function() {
         "onBalanceChange", "origin1", callbackStub
       );
       polkadotEventEmitter.emit("onBalanceChange", "origin1", "arg");
-      expect(callbackStub).to.have.been.calledOnceWith(["arg"]);
+      expect(callbackStub).to.have.been.calledOnceWith("arg");
       polkadotEventEmitter.emit("onBalanceChange", "origin1", "arg");
       expect(callbackStub).to.have.been.calledTwice;
       polkadotEventEmitter.removeAllListeners("onBalanceChange", "origin1");
@@ -54,8 +54,8 @@ describe('Test polkadotEventEmitter', function() {
         "onBalanceChange", "origin1", additionalCallbackStub
       );
       polkadotEventEmitter.emit("onBalanceChange", "origin1", "arg");
-      expect(callbackStub).to.have.been.calledOnceWith(["arg"]);
-      expect(additionalCallbackStub).to.have.been.calledOnceWith(["arg"]);
+      expect(callbackStub).to.have.been.calledOnceWith("arg");
+      expect(additionalCallbackStub).to.have.been.calledOnceWith("arg");
     });
 
     it('should remove all callbacks on same origin', function() {
@@ -69,13 +69,13 @@ describe('Test polkadotEventEmitter', function() {
         "onBalanceChange", "origin1", additionalCallbackStub
       );
       polkadotEventEmitter.emit("onBalanceChange", "origin1", "arg");
-      expect(callbackStub).to.have.been.calledOnceWith(["arg"]);
-      expect(additionalCallbackStub).to.have.been.calledOnceWith(["arg"]);
+      expect(callbackStub).to.have.been.calledOnceWith("arg");
+      expect(additionalCallbackStub).to.have.been.calledOnceWith("arg");
       polkadotEventEmitter.removeAllListeners("onBalanceChange", "origin1");
       // callbacks are removed and wont be called second time
       polkadotEventEmitter.emit("onBalanceChange", "origin1", "arg");
-      expect(callbackStub).to.have.been.calledOnceWith(["arg"]);
-      expect(additionalCallbackStub).to.have.been.calledOnceWith(["arg"]);
+      expect(callbackStub).to.have.been.calledOnceWith("arg");
+      expect(additionalCallbackStub).to.have.been.calledOnceWith("arg");
     });
 
     it('should fail to emit on no listeners subscribed', function () {
@@ -101,12 +101,12 @@ describe('Test polkadotEventEmitter', function() {
         "onBalanceChange", "origin2", secondOriginCallback
       );
       polkadotEventEmitter.emit("onBalanceChange", "origin1", "arg");
-      expect(firstOriginCallback).to.have.been.calledOnceWith(["arg"]);
+      expect(firstOriginCallback).to.have.been.calledOnceWith("arg");
       expect(secondOriginCallback).to.not.have.been.called;
 
       polkadotEventEmitter.emit("onBalanceChange", "origin2", "arg");
-      expect(firstOriginCallback).to.have.been.calledOnceWith(["arg"]);
-      expect(secondOriginCallback).to.have.been.calledOnceWith(["arg"]);
+      expect(firstOriginCallback).to.have.been.calledOnceWith("arg");
+      expect(secondOriginCallback).to.have.been.calledOnceWith("arg");
     });
 
 
@@ -132,7 +132,7 @@ describe('Test polkadotEventEmitter', function() {
 
       expect(firstOriginCallbackOne).not.to.have.been.called;
       expect(firstOriginCallbackTwo).not.to.have.been.called;
-      expect(secondOriginCallback).to.have.been.calledOnceWith(["arg"]);
+      expect(secondOriginCallback).to.have.been.calledOnceWith("arg");
     });
   });
 });

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -143,14 +143,26 @@ export interface SnapConfig {
 
 // Polkadot types
 
-export type EventCallback = (...args: unknown[]) => void;
+export type Callback<T> = (arg: T) => void;
+
+export type PolkadotEventArgument = Balance;
+export type PolkadotEventCallback = Callback<PolkadotEventArgument>;
+
+export type TxEventArgument = TxStatus;
+export type TxEventCallback = Callback<TxEventArgument>;
+
+export type Balance = string;
+export type TxStatus = {
+  blockHash: string;
+  txHash: string;
+};
 
 export type Origin = string;
 export type HexHash = string;
 
 export interface PolkadotApi {
-  subscribeToBalance(callback: EventCallback): void;
-  unsubscribeFromBalance(callback: EventCallback): void;
+  subscribeToBalance(callback: PolkadotEventCallback): void;
+  unsubscribeFromBalance(callback: PolkadotEventCallback): void;
   unsubscribeAllFromBalance(): void;
-  subscribeToTxStatus(hash: HexHash, onIncluded: EventCallback, onFinalized?: EventCallback): void;
+  subscribeToTxStatus(hash: HexHash, onIncluded: TxEventCallback, onFinalized?: TxEventCallback): void;
 }

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -153,7 +153,6 @@ export type TxEventCallback = Callback<TxEventArgument>;
 
 export type Balance = string;
 export type TxStatus = {
-  blockHash: string;
   txHash: string;
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2093,7 +2093,7 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@nodefactory/snaps-cli@^1.0.0":
+"@nodefactory/snaps-cli@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@nodefactory/snaps-cli/-/snaps-cli-1.0.0.tgz#6f89a3ef8421c1f64e43906a51aaacac6e64c69b"
   integrity sha512-6JbPXvSvw+447///S6Ky1pBOxo2n7xjRzGMnzBY4UInOXjfBSkHeviufDJfeQXE4EB+yNV70rHI43NEgj40+Bg==


### PR DESCRIPTION
Fixed bugs:
- Balance subscription not working because of wrong callback argument type
- Clear fields after sending units
- Fix asset balance not changing inside Metamask on balance change event

Changes:
- Change default denomination for Westend to `mWND` inside `Transfer` component