### PR TITLE
Integrate addAsset function inside snap flow

### DIFF
--- a/packages/adapter/src/methods.ts
+++ b/packages/adapter/src/methods.ts
@@ -41,10 +41,6 @@ export async function signPayloadRaw(this: MetamaskPolkadotSnap, payload: Signer
   return (await sign.bind(this)("signPayloadRaw", payload)).signature;
 }
 
-export async function addPolkadotAsset(this: MetamaskPolkadotSnap): Promise<void> {
-  await sendSnapMethod({method: "addPolkadotAsset"}, this.snapId);
-}
-
 export async function getBalance(this: MetamaskPolkadotSnap): Promise<string> {
   return (await sendSnapMethod({method: "getBalance"}, this.snapId)) as string;
 }

--- a/packages/adapter/src/snap.ts
+++ b/packages/adapter/src/snap.ts
@@ -2,7 +2,6 @@ import {Injected, InjectedAccount, InjectedAccounts} from "@polkadot/extension-i
 import {Signer as InjectedSigner, SignerResult} from '@polkadot/api/types';
 import {SignerPayloadJSON, SignerPayloadRaw} from '@polkadot/types/types';
 import {
-  addPolkadotAsset,
   exportSeed,
   generateTransactionPayload,
   getAddress,
@@ -78,14 +77,12 @@ export class MetamaskPolkadotSnap implements Injected {
         }]
       });
       await setConfiguration.bind(this)(this.config);
-      await addPolkadotAsset.bind(this)();
     }
     return this;
   };
 
   public getMetamaskSnapApi = async (): Promise<MetamaskSnapApi> => {
     return {
-      addPolkadotAsset: addPolkadotAsset.bind(this),
       exportSeed: exportSeed.bind(this),
       generateTransactionPayload: generateTransactionPayload.bind(this),
       getAllTransactions: getAllTransactions.bind(this),

--- a/packages/adapter/src/types.ts
+++ b/packages/adapter/src/types.ts
@@ -8,7 +8,6 @@ import {
 import {InjectedExtension} from "@polkadot/extension-inject/types";
 
 export interface MetamaskSnapApi {
-  addPolkadotAsset(): Promise<void>;
   getPublicKey(): Promise<string>;
   getBalance(): Promise<string>;
   exportSeed(): Promise<string>;

--- a/packages/example/src/containers/MetaMaskConnector/MetaMaskConnector.tsx
+++ b/packages/example/src/containers/MetaMaskConnector/MetaMaskConnector.tsx
@@ -19,6 +19,7 @@ export const MetaMaskConnector = () => {
 
     const installSnap = useCallback(async () => {
        const isInitiated = await installPolkadotSnap();
+       console.log(`SNAP INSTALLED: ${isInitiated}`);
        if(!isInitiated) {
            dispatch({type: MetamaskActions.SET_INSTALLED_STATUS, payload: {isInstalled: false, message: "Please accept snap installation prompt"}})
        } else {

--- a/packages/example/src/containers/MetaMaskConnector/MetaMaskConnector.tsx
+++ b/packages/example/src/containers/MetaMaskConnector/MetaMaskConnector.tsx
@@ -19,7 +19,6 @@ export const MetaMaskConnector = () => {
 
     const installSnap = useCallback(async () => {
        const isInitiated = await installPolkadotSnap();
-       console.log(`SNAP INSTALLED: ${isInitiated}`);
        if(!isInitiated) {
            dispatch({type: MetamaskActions.SET_INSTALLED_STATUS, payload: {isInstalled: false, message: "Please accept snap installation prompt"}})
        } else {

--- a/packages/snap/src/asset/index.ts
+++ b/packages/snap/src/asset/index.ts
@@ -40,10 +40,17 @@ export async function updateAsset(
   const configuration = getConfiguration(wallet);
   const assetId = configuration.unit.assetId;
   console.log("Updating asset", origin, assetId);
+  console.log("Current saved assets");
+  assets.forEach((value, key) => console.log(`${key}::${value}`));
   if(assets.has(getIdentifier(origin, assetId))) {
     const asset = assets.get(getIdentifier(origin, assetId));
-    asset.balance = formatBalance(balance, {decimals: 12, withSi: true, withUnit: false});
-    await executeAssetOperation(asset, wallet, "update");
+    const newBalance = formatBalance(balance, {decimals: 12, withSi: true, withUnit: false});
+    console.log(`OLD BALANCE:${asset.balance} // NEW BALANCE:${newBalance}`);
+    if (asset.balance !== newBalance) {
+      asset.balance = formatBalance(balance, {decimals: 12, withSi: true, withUnit: false});
+      console.log("EXECUTING UPDATE");
+      await executeAssetOperation(asset, wallet, "update");
+    }
   } else {
     const asset = getPolkadotAssetDescription(0, await getAddress(wallet), configuration);
     await removeAsset(wallet, origin);

--- a/packages/snap/src/asset/index.ts
+++ b/packages/snap/src/asset/index.ts
@@ -29,8 +29,10 @@ export function getPolkadotAssetDescription(
 export async function removeAsset(wallet: Wallet, origin: string): Promise<boolean> {
   const configuration = getConfiguration(wallet);
   const assetId = configuration.unit.assetId;
-  await executeAssetOperation({identifier: assetId}, wallet, "remove");
-  assets.delete(getIdentifier(origin, assetId));
+  if (assets.size != 0) {
+    await executeAssetOperation({identifier: assetId}, wallet, "remove");
+    assets.delete(getIdentifier(origin, assetId));
+  }
   return true;
 }
 
@@ -39,16 +41,12 @@ export async function updateAsset(
 ): Promise<boolean> {
   const configuration = getConfiguration(wallet);
   const assetId = configuration.unit.assetId;
-  console.log("Updating asset", origin, assetId);
-  console.log("Current saved assets");
   assets.forEach((value, key) => console.log(`${key}::${value}`));
   if(assets.has(getIdentifier(origin, assetId))) {
     const asset = assets.get(getIdentifier(origin, assetId));
     const newBalance = formatBalance(balance, {decimals: 12, withSi: true, withUnit: false});
-    console.log(`OLD BALANCE:${asset.balance} // NEW BALANCE:${newBalance}`);
     if (asset.balance !== newBalance) {
       asset.balance = formatBalance(balance, {decimals: 12, withSi: true, withUnit: false});
-      console.log("EXECUTING UPDATE");
       await executeAssetOperation(asset, wallet, "update");
     }
   } else {

--- a/packages/snap/src/asset/index.ts
+++ b/packages/snap/src/asset/index.ts
@@ -41,10 +41,10 @@ export async function updateAsset(
 ): Promise<boolean> {
   const configuration = getConfiguration(wallet);
   const assetId = configuration.unit.assetId;
-  assets.forEach((value, key) => console.log(`${key}::${value}`));
   if(assets.has(getIdentifier(origin, assetId))) {
     const asset = assets.get(getIdentifier(origin, assetId));
     const newBalance = formatBalance(balance, {decimals: 12, withSi: true, withUnit: false});
+    // update if balance changed
     if (asset.balance !== newBalance) {
       asset.balance = formatBalance(balance, {decimals: 12, withSi: true, withUnit: false});
       await executeAssetOperation(asset, wallet, "update");

--- a/packages/snap/src/snap.ts
+++ b/packages/snap/src/snap.ts
@@ -89,13 +89,15 @@ wallet.registerRpcMessageHandler(async (originString, requestObject) => {
         resetApi();
       }
       // set new configuration
-      const configuration = configure(wallet, requestObject.params.configuration.networkName, requestObject.params.configuration);
+      const configuration = configure(
+        wallet, requestObject.params.configuration.networkName, requestObject.params.configuration
+      );
       // initialize api with new configuration
       api = await getApi(wallet);
       // add new asset
       const balance = await getBalance(wallet, api);
       await updateAsset(wallet, originString, balance);
-      return configuration
+      return configuration;
     }
     case "generateTransactionPayload":
       return await generateTransactionPayload(wallet, api, requestObject.params.to, requestObject.params.amount);

--- a/packages/snap/src/snap.ts
+++ b/packages/snap/src/snap.ts
@@ -97,8 +97,6 @@ wallet.registerRpcMessageHandler(async (originString, requestObject) => {
       await updateAsset(wallet, originString, balance);
       return configuration
     }
-    case 'removePolkadotAsset':
-      return await removeAsset(wallet, originString);
     case "generateTransactionPayload":
       return await generateTransactionPayload(wallet, api, requestObject.params.to, requestObject.params.amount);
     case "send":

--- a/packages/snap/src/snap.ts
+++ b/packages/snap/src/snap.ts
@@ -19,7 +19,7 @@ import {send} from "./rpc/send";
 declare let wallet: Wallet;
 
 const apiDependentMethods = [
-  "getBlock", "getBalance", "getChainHead", "signPayloadJSON", "signPayloadRaw", "generateTransactionPayload", "send",
+  "getBlock", "getBalance", "getChainHead", "signPayloadJSON", "signPayloadRaw", "generateTransactionPayload", "send"
 ];
 
 wallet.registerApiRequestHandler(async function (origin: URL): Promise<PolkadotApi> {

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -42,10 +42,6 @@ export interface AddPolkadotAssetRequest {
   method: "addPolkadotAsset";
 }
 
-export interface RemovePolkadotAssetRequest {
-  method: "removePolkadotAsset";
-}
-
 export interface GetChainHeadRequest {
   method: "getChainHead";
 }
@@ -89,7 +85,6 @@ export type MetamaskPolkadotRpcRequest =
     | GetBalanceRequest
     | ConfigureSnapRequest
     | AddPolkadotAssetRequest
-    | RemovePolkadotAssetRequest
     | GetChainHeadRequest
     | SignPayloadJSONRequest
     | SignPayloadRawRequest


### PR DESCRIPTION
Closes #85 

Additionally, I removed `removeAsset` as the idea was to remove raw asset management from API (this function actually wasn't being used).

This PR doesn't resolve asset duplication bug, I will fix that in separate PR.