### PR TITLE
Refactor asset management

### DIFF
--- a/packages/snap/src/asset/index.ts
+++ b/packages/snap/src/asset/index.ts
@@ -6,7 +6,7 @@ import {Balance} from "@polkadot/types/interfaces";
 import {getConfiguration} from "../configuration";
 import {SnapConfig} from "@nodefactory/metamask-polkadot-types";
 
-const polkadotSnapAssetIdentifier = "POLKADOT-SNAP-ASSET";
+export const polkadotSnapAssetIdentifier = "POLKADOT-SNAP-ASSET";
 
 export function getPolkadotAssetDescription(
   balance: number|string|Balance, address: string, configuration: SnapConfig

--- a/packages/snap/src/asset/index.ts
+++ b/packages/snap/src/asset/index.ts
@@ -16,7 +16,7 @@ export function getPolkadotAssetDescription(
     customViewUrl: configuration.unit.customViewUrl ||
         `https://polkascan.io/pre/${configuration.networkName}/account/${address}`,
     decimals: 0,
-      identifier: POLKADOT_SNAP_ASSET_IDENTIFIER,
+    identifier: POLKADOT_SNAP_ASSET_IDENTIFIER,
     image: configuration.unit.image || "",
     symbol: configuration.unit.symbol,
   };

--- a/packages/snap/src/asset/index.ts
+++ b/packages/snap/src/asset/index.ts
@@ -6,7 +6,7 @@ import {Balance} from "@polkadot/types/interfaces";
 import {getConfiguration} from "../configuration";
 import {SnapConfig} from "@nodefactory/metamask-polkadot-types";
 
-const polkadotSnapAssetIdentifier = "polkadot-snap-asset";
+const polkadotSnapAssetIdentifier = "POLKADOT-SNAP-ASSET";
 
 export function getPolkadotAssetDescription(
   balance: number|string|Balance, address: string, configuration: SnapConfig

--- a/packages/snap/src/asset/index.ts
+++ b/packages/snap/src/asset/index.ts
@@ -16,7 +16,7 @@ export function getPolkadotAssetDescription(
     customViewUrl: configuration.unit.customViewUrl ||
         `https://polkascan.io/pre/${configuration.networkName}/account/${address}`,
     decimals: 0,
-      identifier: polkadotSnapAssetIdentifier,
+    identifier: polkadotSnapAssetIdentifier,
     image: configuration.unit.image || "",
     symbol: configuration.unit.symbol,
   };
@@ -28,14 +28,14 @@ export async function updateAsset(
   wallet: Wallet, origin: string, balance: number|string|Balance
 ): Promise<void> {
   const configuration = getConfiguration(wallet);
-    // const newBalance = formatBalance(balance, {decimals: 12, withSi: true, withUnit: false});
-    const asset = getPolkadotAssetDescription(balance, await getAddress(wallet), configuration);
-    if (!assetState) {
-        // create polkadot snap asset
+  // const newBalance = formatBalance(balance, {decimals: 12, withSi: true, withUnit: false});
+  const asset = getPolkadotAssetDescription(balance, await getAddress(wallet), configuration);
+  if (!assetState) {
+    // create polkadot snap asset
     await executeAssetOperation(asset, wallet, "add");
-    } else if (assetState.balance !== asset.balance || assetState.network !== configuration.networkName) {
-        // update if balance or network changed
-        await executeAssetOperation(asset, wallet, "update");
-    }
-    assetState = {balance: asset.balance, network: configuration.networkName};
+  } else if (assetState.balance !== asset.balance || assetState.network !== configuration.networkName) {
+    // update if balance or network changed
+    await executeAssetOperation(asset, wallet, "update");
+  }
+  assetState = {balance: asset.balance, network: configuration.networkName};
 }

--- a/packages/snap/src/asset/index.ts
+++ b/packages/snap/src/asset/index.ts
@@ -6,7 +6,7 @@ import {Balance} from "@polkadot/types/interfaces";
 import {getConfiguration} from "../configuration";
 import {SnapConfig} from "@nodefactory/metamask-polkadot-types";
 
-export const polkadotSnapAssetIdentifier = "POLKADOT-SNAP-ASSET";
+export const POLKADOT_SNAP_ASSET_IDENTIFIER = "polkadot-snap-asset";
 
 export function getPolkadotAssetDescription(
   balance: number|string|Balance, address: string, configuration: SnapConfig
@@ -16,7 +16,7 @@ export function getPolkadotAssetDescription(
     customViewUrl: configuration.unit.customViewUrl ||
         `https://polkascan.io/pre/${configuration.networkName}/account/${address}`,
     decimals: 0,
-    identifier: polkadotSnapAssetIdentifier,
+      identifier: POLKADOT_SNAP_ASSET_IDENTIFIER,
     image: configuration.unit.image || "",
     symbol: configuration.unit.symbol,
   };

--- a/packages/snap/src/configuration/predefined.ts
+++ b/packages/snap/src/configuration/predefined.ts
@@ -4,7 +4,6 @@ export const kusamaConfiguration: SnapConfig = {
   addressPrefix: 2,
   networkName: "kusama",
   unit: {
-    assetId: "ksm-token",
     decimals: 12,
     image: "https://svgshare.com/i/L3o.svg",
     symbol: "KSM",
@@ -15,7 +14,6 @@ export const westendConfiguration: SnapConfig = {
   addressPrefix: 42,
   networkName: "westend",
   unit: {
-    assetId: "wst-token",
     decimals: 12,
     image: "https://svgshare.com/i/L2d.svg",
     symbol: "WND",

--- a/packages/snap/src/snap.ts
+++ b/packages/snap/src/snap.ts
@@ -6,7 +6,7 @@ import {getAddress} from "./rpc/getAddress";
 import ApiPromise from "@polkadot/api/promise";
 import {getTransactions} from "./rpc/substrate/getTransactions";
 import {getBlock} from "./rpc/substrate/getBlock";
-import {removeAsset, updateAsset} from "./asset";
+import {updateAsset} from "./asset";
 import {getApi, resetApi} from "./polkadot/api";
 import {configure} from "./rpc/configure";
 import {polkadotEventEmitter, txEventEmitter} from "./polkadot/events";
@@ -85,7 +85,6 @@ wallet.registerRpcMessageHandler(async (originString, requestObject) => {
       const isInitialConfiguration = wallet.getPluginState().polkadot.config === null;
       // reset api and remove asset only if already configured
       if (!isInitialConfiguration) {
-        await removeAsset(wallet, originString);
         resetApi();
       }
       // set new configuration

--- a/packages/snap/test/unit/asset/index.test.ts
+++ b/packages/snap/test/unit/asset/index.test.ts
@@ -17,7 +17,7 @@ describe('Test asset functions ', function() {
         { // configuration
           networkName: "test-network",
           unit: {
-            assetId: "test-id",
+            assetId: "polkadot-snap-asset",
             customViewUrl: "custom-view",
             decimals: 5,
             image: "test-image",
@@ -31,7 +31,7 @@ describe('Test asset functions ', function() {
         balance: "1.000m",
         customViewUrl: "custom-view",
         decimals: 0,
-        identifier: "test-id",
+        identifier: "polkadot-snap-asset",
         image: "test-image",
         symbol: "TST"
       } as Asset);
@@ -44,7 +44,7 @@ describe('Test asset functions ', function() {
         { // configuration
           networkName: "test-network",
           unit: {
-            assetId: "test-id",
+            assetId: "polkadot-snap-asset",
             decimals: 5,
             symbol: "TST",
             // missing: image && customViewUrl
@@ -57,7 +57,7 @@ describe('Test asset functions ', function() {
         balance: "1.000m",
         customViewUrl: "https://polkascan.io/pre/test-network/account/test-address",
         decimals: 0,
-        identifier: "test-id",
+        identifier: "polkadot-snap-asset",
         image: "",
         symbol: "TST"
       } as Asset);

--- a/packages/snap/test/unit/asset/index.test.ts
+++ b/packages/snap/test/unit/asset/index.test.ts
@@ -1,7 +1,7 @@
 import chai, {expect} from "chai";
 import sinonChai from "sinon-chai";
 import {Asset} from "../../../src/interfaces";
-import {getPolkadotAssetDescription} from "../../../src/asset";
+import {getPolkadotAssetDescription, polkadotSnapAssetIdentifier} from "../../../src/asset";
 import {SnapConfig} from "@nodefactory/metamask-polkadot-types";
 
 chai.use(sinonChai);
@@ -17,7 +17,7 @@ describe('Test asset functions ', function() {
         { // configuration
           networkName: "test-network",
           unit: {
-            assetId: "polkadot-snap-asset",
+              assetId: polkadotSnapAssetIdentifier,
             customViewUrl: "custom-view",
             decimals: 5,
             image: "test-image",
@@ -31,7 +31,7 @@ describe('Test asset functions ', function() {
         balance: "1.000m",
         customViewUrl: "custom-view",
         decimals: 0,
-        identifier: "polkadot-snap-asset",
+          identifier: polkadotSnapAssetIdentifier,
         image: "test-image",
         symbol: "TST"
       } as Asset);
@@ -44,7 +44,7 @@ describe('Test asset functions ', function() {
         { // configuration
           networkName: "test-network",
           unit: {
-            assetId: "polkadot-snap-asset",
+              assetId: polkadotSnapAssetIdentifier,
             decimals: 5,
             symbol: "TST",
             // missing: image && customViewUrl
@@ -57,7 +57,7 @@ describe('Test asset functions ', function() {
         balance: "1.000m",
         customViewUrl: "https://polkascan.io/pre/test-network/account/test-address",
         decimals: 0,
-        identifier: "polkadot-snap-asset",
+          identifier: polkadotSnapAssetIdentifier,
         image: "",
         symbol: "TST"
       } as Asset);

--- a/packages/snap/test/unit/asset/index.test.ts
+++ b/packages/snap/test/unit/asset/index.test.ts
@@ -1,7 +1,7 @@
 import chai, {expect} from "chai";
 import sinonChai from "sinon-chai";
 import {Asset} from "../../../src/interfaces";
-import {getPolkadotAssetDescription, polkadotSnapAssetIdentifier} from "../../../src/asset";
+import {getPolkadotAssetDescription, POLKADOT_SNAP_ASSET_IDENTIFIER} from "../../../src/asset";
 import {SnapConfig} from "@nodefactory/metamask-polkadot-types";
 
 chai.use(sinonChai);
@@ -17,7 +17,7 @@ describe('Test asset functions ', function() {
         { // configuration
           networkName: "test-network",
           unit: {
-              assetId: polkadotSnapAssetIdentifier,
+            assetId: POLKADOT_SNAP_ASSET_IDENTIFIER,
             customViewUrl: "custom-view",
             decimals: 5,
             image: "test-image",
@@ -31,7 +31,7 @@ describe('Test asset functions ', function() {
         balance: "1.000m",
         customViewUrl: "custom-view",
         decimals: 0,
-          identifier: polkadotSnapAssetIdentifier,
+        identifier: POLKADOT_SNAP_ASSET_IDENTIFIER,
         image: "test-image",
         symbol: "TST"
       } as Asset);
@@ -44,7 +44,7 @@ describe('Test asset functions ', function() {
         { // configuration
           networkName: "test-network",
           unit: {
-              assetId: polkadotSnapAssetIdentifier,
+            assetId: POLKADOT_SNAP_ASSET_IDENTIFIER,
             decimals: 5,
             symbol: "TST",
             // missing: image && customViewUrl
@@ -57,7 +57,7 @@ describe('Test asset functions ', function() {
         balance: "1.000m",
         customViewUrl: "https://polkascan.io/pre/test-network/account/test-address",
         decimals: 0,
-          identifier: polkadotSnapAssetIdentifier,
+        identifier: POLKADOT_SNAP_ASSET_IDENTIFIER,
         image: "",
         symbol: "TST"
       } as Asset);

--- a/packages/snap/test/unit/rpc/configure.test.ts
+++ b/packages/snap/test/unit/rpc/configure.test.ts
@@ -54,7 +54,7 @@ describe('Test rpc handler function: configure', function() {
     const customConfiguration: SnapConfig = {
       addressPrefix: 1,
       networkName: "test-network",
-      unit: {assetId: "test-asset", customViewUrl: "custom-view-url", decimals: 1, image: "image", symbol: "TST" },
+      unit: {customViewUrl: "custom-view-url", decimals: 1, image: "image", symbol: "TST"},
       wsRpcUrl: "ws-rpc-url",
 
     };

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -124,7 +124,6 @@ export interface BlockInfo {
 export interface UnitConfiguration {
   symbol: string;
   decimals: number;
-  assetId: string;
   image?: string;
   customViewUrl?: string;
 }


### PR DESCRIPTION
Closes #82 

- Refactor asset management, so all Polkadot snap assets are defined with same identifier.
- Fix bug of showing multiple assets inside Metamask.