### PR TITLE
Milestone cleanup

### DIFF
--- a/packages/example/src/components/Transfer/Transfer.tsx
+++ b/packages/example/src/components/Transfer/Transfer.tsx
@@ -127,7 +127,7 @@ export const Transfer: React.FC<ITransferProps> = ({network, onNewTransferCallba
                     <Alert severity={severity} onClose={() => setAlert(false)}>
                         {`${message} `}
                         <Hidden xsUp={polkascanUrl === ""}>
-                            <a href={polkascanUrl}>See on Polkascan</a>
+                            <a href={polkascanUrl}>See details</a>
                         </Hidden>
                     </Alert>
                 </Snackbar>

--- a/packages/example/src/services/polkascan.ts
+++ b/packages/example/src/services/polkascan.ts
@@ -1,7 +1,7 @@
 export function getPolkascanTxUrl(txHash: string, network: string): string {
     switch (network) {
         case "kusama":
-            return `https://polkascan.io/pre/kusama/transaction/${txHash}`;
+            return `https://polkascan.io/kusama/transaction/${txHash}`;
         case "westend":
             return `https://westend.subscan.io/extrinsic/${txHash}`;
         default:

--- a/packages/example/src/services/polkascan.ts
+++ b/packages/example/src/services/polkascan.ts
@@ -1,13 +1,9 @@
 export function getPolkascanTxUrl(txHash: string, network: string): string {
-    return `${getPolkascanBaseUrl(network)}/transaction/${txHash}`;
-}
-
-function getPolkascanBaseUrl(network: string): string {
     switch (network) {
         case "kusama":
-            return "https://polkascan.io/pre/kusama";
+            return `https://polkascan.io/pre/kusama/transaction/${txHash}`;
         case "westend":
-            return "https://polkascan.io/pre/westend-m2";
+            return `https://westend.subscan.io/extrinsic/${txHash}`;
         default:
             return "";
     }

--- a/packages/snap/src/asset/index.ts
+++ b/packages/snap/src/asset/index.ts
@@ -13,13 +13,29 @@ export function getPolkadotAssetDescription(
 ): Asset {
   return {
     balance: formatBalance(balance, {decimals: configuration.unit.decimals, withSi: true, withUnit: false}),
-    customViewUrl: configuration.unit.customViewUrl ||
-        `https://polkascan.io/pre/${configuration.networkName}/account/${address}`,
+    customViewUrl: getCustomViewUrl(configuration, address),
     decimals: 0,
     identifier: POLKADOT_SNAP_ASSET_IDENTIFIER,
     image: configuration.unit.image || "",
     symbol: configuration.unit.symbol,
   };
+}
+
+function getCustomViewUrl(configuration: SnapConfig, address: string): string {
+  if (configuration.unit.customViewUrl) {
+    // defined in configuration
+      return configuration.unit.customViewUrl;
+  } else {
+    // generate from network name
+    switch (configuration.networkName) {
+      case "kusama":
+        return `https://polkascan.io/pre/${configuration.networkName}/account/${address}`;
+      case "westend":
+        return `https://westend.subscan.io/account/${address}`;
+      default:
+        return "";
+    }
+  }
 }
 
 let assetState: { balance: string | number; network: string };

--- a/packages/snap/src/asset/index.ts
+++ b/packages/snap/src/asset/index.ts
@@ -8,29 +8,12 @@ import {SnapConfig} from "@nodefactory/metamask-polkadot-types";
 
 export const POLKADOT_SNAP_ASSET_IDENTIFIER = "polkadot-snap-asset";
 
-function getCustomViewUrl(configuration: SnapConfig, address: string): string {
-  if (configuration.unit.customViewUrl) {
-    // defined in configuration
-    return configuration.unit.customViewUrl;
-  } else {
-    // generate from network name
-    switch (configuration.networkName) {
-      case "kusama":
-        return `https://polkascan.io/${configuration.networkName}/account/${address}`;
-      case "westend":
-        return `https://westend.subscan.io/account/${address}`;
-      default:
-        return "";
-    }
-  }
-}
-
 export function getPolkadotAssetDescription(
   balance: number|string|Balance, address: string, configuration: SnapConfig
 ): Asset {
   return {
     balance: formatBalance(balance, {decimals: configuration.unit.decimals, withSi: true, withUnit: false}),
-    customViewUrl: getCustomViewUrl(configuration, address),
+    customViewUrl: configuration.unit.customViewUrl || "",
     decimals: 0,
     identifier: POLKADOT_SNAP_ASSET_IDENTIFIER,
     image: configuration.unit.image || "",

--- a/packages/snap/src/asset/index.ts
+++ b/packages/snap/src/asset/index.ts
@@ -8,6 +8,23 @@ import {SnapConfig} from "@nodefactory/metamask-polkadot-types";
 
 export const POLKADOT_SNAP_ASSET_IDENTIFIER = "polkadot-snap-asset";
 
+function getCustomViewUrl(configuration: SnapConfig, address: string): string {
+  if (configuration.unit.customViewUrl) {
+    // defined in configuration
+    return configuration.unit.customViewUrl;
+  } else {
+    // generate from network name
+    switch (configuration.networkName) {
+      case "kusama":
+        return `https://polkascan.io/${configuration.networkName}/account/${address}`;
+      case "westend":
+        return `https://westend.subscan.io/account/${address}`;
+      default:
+        return "";
+    }
+  }
+}
+
 export function getPolkadotAssetDescription(
   balance: number|string|Balance, address: string, configuration: SnapConfig
 ): Asset {
@@ -19,23 +36,6 @@ export function getPolkadotAssetDescription(
     image: configuration.unit.image || "",
     symbol: configuration.unit.symbol,
   };
-}
-
-function getCustomViewUrl(configuration: SnapConfig, address: string): string {
-  if (configuration.unit.customViewUrl) {
-    // defined in configuration
-      return configuration.unit.customViewUrl;
-  } else {
-    // generate from network name
-    switch (configuration.networkName) {
-      case "kusama":
-        return `https://polkascan.io/pre/${configuration.networkName}/account/${address}`;
-      case "westend":
-        return `https://westend.subscan.io/account/${address}`;
-      default:
-        return "";
-    }
-  }
 }
 
 let assetState: { balance: string | number; network: string };

--- a/packages/snap/test/unit/asset/index.test.ts
+++ b/packages/snap/test/unit/asset/index.test.ts
@@ -42,7 +42,7 @@ describe('Test asset functions ', function() {
         100,
         "test-address",
         { // configuration
-          networkName: "test-network",
+          networkName: "kusama",
           unit: {
             assetId: POLKADOT_SNAP_ASSET_IDENTIFIER,
             decimals: 5,
@@ -55,7 +55,7 @@ describe('Test asset functions ', function() {
       expect(asset).not.to.be.null;
       expect(asset).to.be.deep.eq({
         balance: "1.000m",
-        customViewUrl: "https://polkascan.io/pre/test-network/account/test-address",
+        customViewUrl: "https://polkascan.io/kusama/account/test-address",
         decimals: 0,
         identifier: POLKADOT_SNAP_ASSET_IDENTIFIER,
         image: "",

--- a/packages/snap/test/unit/asset/index.test.ts
+++ b/packages/snap/test/unit/asset/index.test.ts
@@ -55,7 +55,7 @@ describe('Test asset functions ', function() {
       expect(asset).not.to.be.null;
       expect(asset).to.be.deep.eq({
         balance: "1.000m",
-        customViewUrl: "https://polkascan.io/kusama/account/test-address",
+        customViewUrl: "",
         decimals: 0,
         identifier: POLKADOT_SNAP_ASSET_IDENTIFIER,
         image: "",


### PR DESCRIPTION
I fixed explorers url-s as now westend is not supported on polkascan.

Everything else seems to be working, but I am still investigating #79 as it messes with snap after few operations (` MaxListenersExceededWarning`). 

If you look _relevant code from Polkadot API_ that I mentioned inside issue #79 you will see that `promiseTracker` function is used and that unsubscribe callback fails with the illegal invocation error. This is interesting as this same mechanism (creating tracker with `promiseTracker` function) is used when subscribing to different events inside Polkadot API, and it resolves with the same error (because of this we made the last fix on snaps-cli). 

In conclusion I think we will fix more than one problem by figuring out why this happens. Unfortunately, [issue](https://github.com/MetaMask/metamask-snaps-beta/issues/133) on Metamask repo to return more meaningful error message is still not resolved but I am investigating this.