### PR TITLE
Update adapter version and change ipfs url

### DIFF
--- a/packages/adapter/package.json
+++ b/packages/adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nodefactory/metamask-polkadot-adapter",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "./build/index.js",
   "module": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/packages/adapter/src/index.ts
+++ b/packages/adapter/src/index.ts
@@ -3,7 +3,7 @@ import {MetamaskPolkadotSnap} from "./snap";
 import {SnapConfig} from "@nodefactory/metamask-polkadot-types";
 import {hasMetaMask} from "./utils";
 
-const defaultOrigin = "https://ipfs.infura.io/ipfs/QmfLTuyTKn5Ax66t3fDf4nzMY79dSQ6nHzSN7SepHRH9kz/";
+const defaultOrigin = "https://bafybeih426v3jpdwnltjfmeefyt4isrogvgzg2wxvryu6itodvb4vzvuma.ipfs.infura-ipfs.io/";
 
 /**
  *


### PR DESCRIPTION
Published new versions on **IPFS**:

_package.json_: https://bafybeih426v3jpdwnltjfmeefyt4isrogvgzg2wxvryu6itodvb4vzvuma.ipfs.infura-ipfs.io/
_bundle.js_: https://bafybeie2jshn6okklqkugkpdryeseygfadafywmg3xgbtjkhjjlbv3lrxu.ipfs.infura-ipfs.io/

Published version `0.3.1` of [adapter](https://www.npmjs.com/package/@nodefactory/metamask-polkadot-adapter) to npm (_changed url to ipfs_)

